### PR TITLE
Don't instantiate new LoggerAtLevels each time

### DIFF
--- a/src/main/java/org/fissore/slf4j/FluentLogger.java
+++ b/src/main/java/org/fissore/slf4j/FluentLogger.java
@@ -6,49 +6,57 @@ public class FluentLogger {
 
     private static final LoggerAtLevel NOOP_LOGGER = new NOOPLogger();
 
-    private final Logger logger;
+    private final LoggerAtLevel infoLogger;
+    private final LoggerAtLevel debugLogger;
+    private final LoggerAtLevel errorLogger;
+    private final LoggerAtLevel traceLogger;
+    private final LoggerAtLevel warnLogger;
 
     public FluentLogger(Logger logger) {
-        this.logger = logger;
+        if (!logger.isInfoEnabled()) {
+            this.infoLogger = NOOP_LOGGER;
+        } else {
+            this.infoLogger = new LoggerAtLevel(logger::info);
+        }
+        if (!logger.isDebugEnabled()) {
+            this.debugLogger = NOOP_LOGGER;
+        } else {
+            this.debugLogger = new LoggerAtLevel(logger::debug);
+        }
+        if (!logger.isErrorEnabled()) {
+            this.errorLogger = NOOP_LOGGER;
+        } else {
+            this.errorLogger = new LoggerAtLevel(logger::error);
+        }
+        if (!logger.isTraceEnabled()) {
+            this.traceLogger = NOOP_LOGGER;
+        } else {
+            this.traceLogger = new LoggerAtLevel(logger::trace);
+        }
+        if (!logger.isWarnEnabled()) {
+            this.warnLogger = NOOP_LOGGER;
+        } else {
+            this.warnLogger = new LoggerAtLevel(logger::warn);
+        }
     }
 
     public LoggerAtLevel atInfo() {
-        if (!logger.isInfoEnabled()) {
-            return NOOP_LOGGER;
-        }
-
-        return new LoggerAtLevel(logger::info);
+        return infoLogger;
     }
 
     public LoggerAtLevel atDebug() {
-        if (!logger.isDebugEnabled()) {
-            return NOOP_LOGGER;
-        }
-
-        return new LoggerAtLevel(logger::debug);
+        return debugLogger;
     }
 
     public LoggerAtLevel atError() {
-        if (!logger.isErrorEnabled()) {
-            return NOOP_LOGGER;
-        }
-
-        return new LoggerAtLevel(logger::error);
+        return errorLogger;
     }
 
     public LoggerAtLevel atTrace() {
-        if (!logger.isTraceEnabled()) {
-            return NOOP_LOGGER;
-        }
-
-        return new LoggerAtLevel(logger::trace);
+        return traceLogger;
     }
 
     public LoggerAtLevel atWarn() {
-        if (!logger.isWarnEnabled()) {
-            return NOOP_LOGGER;
-        }
-
-        return new LoggerAtLevel(logger::warn);
+        return warnLogger;
     }
 }


### PR DESCRIPTION
Instantiating all loggers in FluentLogger constructor, thus not creating new instances each time an at* method is called