### PR TITLE
Logging the correct class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Add slf4j-fluent as a dependency to your project
 <dependency> 
   <groupId>org.fissore</groupId>
   <artifactId>slf4j-fluent</artifactId>
-  <version>0.8.0</version>
+  <version>0.9.0</version>
 </dependency>
 ```
 
@@ -83,10 +83,3 @@ log.error().every(1, ChronoUnit.SECONDS).log("Errors occured, but we print only 
 ## Trivia
 
 The fluent API looks a lot like that of [Flogger](https://github.com/google/flogger), which however has the downside of being yet-another-logging-framework.
-
-## Known issues
-
-Because slf4j-fluent **wraps** slf4j, the "calling class" slf4j will log will be `org.fissore.slf4j.LoggerAtLevel` rather than your class.
-If your logging framework pattern layout contains calling class information (for example `%C`, `%caller`, `%l`, `%L`, `%F`, `%M` in both logback and log4j), you'll get wrong log entries.
-
-There's no available fix at the moment. If that's a blocker, don't use slf4j-fluent.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.fissore</groupId>
   <artifactId>slf4j-fluent</artifactId>
-  <version>0.8.0</version>
+  <version>0.9.0</version>
   <packaging>jar</packaging>
 
   <name>slf4j-fluent</name>

--- a/src/main/java/org/fissore/slf4j/FluentLogger.java
+++ b/src/main/java/org/fissore/slf4j/FluentLogger.java
@@ -1,6 +1,7 @@
 package org.fissore.slf4j;
 
 import org.slf4j.Logger;
+import org.slf4j.spi.LocationAwareLogger;
 
 /**
  * FluentLogger is what we use to start logging at different levels. It exposes log levels as no-arg methods ({@code info}, {@code debug}, {@code error}...) that will return either a new {@link LoggerAtLevel} instance (if logging at that level is enabled) or a shared {@link NOOPLogger} instance.
@@ -10,6 +11,7 @@ public class FluentLogger {
   private static final NOOPLogger NOOP_LOGGER = new NOOPLogger();
 
   private final Logger logger;
+  private final boolean isLocationAwareLogger;
 
   /**
    * Creates a new {@link FluentLogger} wrapping a {@link Logger}.
@@ -18,6 +20,7 @@ public class FluentLogger {
    */
   public FluentLogger(Logger logger) {
     this.logger = logger;
+    this.isLocationAwareLogger = logger instanceof LocationAwareLogger;
   }
 
   /**
@@ -30,7 +33,7 @@ public class FluentLogger {
       return NOOP_LOGGER;
     }
 
-    return new LoggerAtLevel(logger::info);
+    return new LoggerAtLevel(logger::info, isLocationAwareLogger, logger, LocationAwareLogger.INFO_INT);
   }
 
   /**
@@ -43,7 +46,7 @@ public class FluentLogger {
       return NOOP_LOGGER;
     }
 
-    return new LoggerAtLevel(logger::debug);
+    return new LoggerAtLevel(logger::debug, isLocationAwareLogger, logger, LocationAwareLogger.DEBUG_INT);
   }
 
   /**
@@ -56,7 +59,7 @@ public class FluentLogger {
       return NOOP_LOGGER;
     }
 
-    return new LoggerAtLevel(logger::error);
+    return new LoggerAtLevel(logger::error, isLocationAwareLogger, logger, LocationAwareLogger.ERROR_INT);
   }
 
   /**
@@ -69,7 +72,7 @@ public class FluentLogger {
       return NOOP_LOGGER;
     }
 
-    return new LoggerAtLevel(logger::trace);
+    return new LoggerAtLevel(logger::trace, isLocationAwareLogger, logger, LocationAwareLogger.TRACE_INT);
   }
 
   /**
@@ -82,6 +85,6 @@ public class FluentLogger {
       return NOOP_LOGGER;
     }
 
-    return new LoggerAtLevel(logger::warn);
+    return new LoggerAtLevel(logger::warn, isLocationAwareLogger, logger, LocationAwareLogger.WARN_INT);
   }
 }

--- a/src/main/java/org/fissore/slf4j/NOOPLogger.java
+++ b/src/main/java/org/fissore/slf4j/NOOPLogger.java
@@ -6,7 +6,7 @@ package org.fissore.slf4j;
 public class NOOPLogger extends LoggerAtLevel {
 
   public NOOPLogger() {
-    super(null);
+    super(null, false, null, -1);
   }
 
   @Override

--- a/src/test/java/org/fissore/test/slf4j/LoggedContentsTest.java
+++ b/src/test/java/org/fissore/test/slf4j/LoggedContentsTest.java
@@ -1,5 +1,6 @@
 package org.fissore.test.slf4j;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.fissore.slf4j.FluentLogger;
 import org.fissore.slf4j.FluentLoggerFactory;
 import org.junit.Before;
@@ -9,8 +10,9 @@ import java.util.function.Supplier;
 
 import static org.fissore.slf4j.Util.lazy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class ContentsLoggedTest {
+public class LoggedContentsTest {
 
   @Before
   public void setUp() {
@@ -33,6 +35,7 @@ public class ContentsLoggedTest {
     logger.error().withCause(new Exception()).log("error 2 args with exception {} {}", "one", (Supplier<?>) () -> "two");
 
     assertEquals(10, TestConsoleAppender.EVENTS.size());
+
     assertEquals("error no args", TestConsoleAppender.EVENTS.get(0).getFormattedMessage());
     assertEquals("error 1 arg one", TestConsoleAppender.EVENTS.get(1).getFormattedMessage());
     assertEquals("error 2 args one two", TestConsoleAppender.EVENTS.get(2).getFormattedMessage());
@@ -43,6 +46,15 @@ public class ContentsLoggedTest {
     assertEquals("error 6 args one null null four five six", TestConsoleAppender.EVENTS.get(7).getFormattedMessage());
     assertEquals("error null varargs", TestConsoleAppender.EVENTS.get(8).getFormattedMessage());
     assertEquals("error 2 args with exception one two", TestConsoleAppender.EVENTS.get(9).getFormattedMessage());
+
+    int lineNumber = 26;
+    for (ILoggingEvent event : TestConsoleAppender.EVENTS) {
+      assertTrue(event.getCallerData().length > 0);
+      assertEquals(getClass().getName(), event.getCallerData()[0].getClassName());
+      assertEquals("errorLoggerContents", event.getCallerData()[0].getMethodName());
+      assertEquals(lineNumber, event.getCallerData()[0].getLineNumber());
+      lineNumber++;
+    }
   }
 
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
 
   <appender name="STDOUT" class="org.fissore.test.slf4j.TestConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %C@%M:%L %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
If the underlying logger is an instance of LocationAwareLogger, and the pattern layout includes class name, method, or line number, the correct values are logged. Fixes #3